### PR TITLE
readme: clean up the process; FIXME check

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,49 +27,53 @@ avoiding an index for a new page does not help keep something secret.
 
 ### Getting a CVE assignment
 
-In future, let's use GitHub's ability to request a CVE as part of drafting an
-advisory.
+We use GitHub's ability to request a CVE as part of drafting a
+GitHub Security Advisory (GHSA).
 Getting a CVE through the formerly used process has become not expeditious.
 
-~~CVEs are typically requested from MITRE as the CNA of last resort for open
-source projects: <https://cveform.mitre.org/>~~
+Even if we request a CVE via another means, the GHSA should still be created;
+this helps with ecosystem notifications.
 
-~~Fill out enough details to get the number; be accurate, or withhold data, as
-appropriate.  At this first stage, I usually make sure to classify the type of
-vulnerability and the affected version numbers, but not much more.~~
+Cross-reference the GHSA advisory and the CVE in this repository.
 
-~~After the CVE has been published, we can update the text with another use of
-this form.~~
-
+Go to the repository's "Security" tab, "Security advisories" section.  
+Eg: <https://github.com/nats-io/nats-server/security/advisories>.  
+You can and should draft an advisory ahead of time; publishing the advisory is
+almost irreversible.  (It can still be edited, but can't be made private
+again).
 
 ### Other Publications
 
-We create GitHub Security Advisories for any project on GitHub, to aid with
-ecosystem notifications.  Cross-reference the GHSA advisory and the CVE in
-this repository.  See any existing advisory for examples.
+For software which can be used as a Go library, we file an issue to update the
+Go Vulnerability Database, when we go public.  See the next section.
 
 ### Publicising the Advisory
 
-1. The push to the GitHub repo, on any branch, will alert people who have
+1. **Important**: `grep -r FIXME .`  
+   Check that all FIXMEs have been resolved.
+   Learn from Phil's mistakes.
+   See the repo history on 2025-04-08 and help us not repeat this.
+2. The push to the GitHub repo, on any branch, will alert people who have
    watches set up, so from that moment on the public clock is ticking.
-2. Send a copy to the `oss-security` mailing-list, which is the main current
+3. Send a copy to the `oss-security` mailing-list, which is the main current
    announcement mailing-list for open source software security issues;
    <https://oss-security.openwall.org/wiki/mailing-lists/oss-security> /
    <https://www.openwall.com/lists/oss-security/>
-3. Create a GitHub security advisory; this will help downstream users get
-   automatic notifications if they depend upon the affected software.
-   The repository's "Security" tab, "Security advisories" section.  
-   Eg: <https://github.com/nats-io/nats-server/security/advisories>.  
-   You can draft an advisory ahead of time; publishing the advisory is almost
-   irreversible.
-4. For Go vulnerabilities, file an issue to update the
+4. GHSA: _if this is the same text as the advisory here_ (it normally is)
+   then mark this public now.
+   If the text differs, use discretion to establish a publication timeline.
+   + Eg, secnote-2025-01 came from an external report with more detail than we
+     wanted public on the day of announcement, but we didn't want to censor,
+     so publication held back for one week.
+5. For Go vulnerabilities, file an issue to update the
    [Go Vulnerability Database](https://go.dev/security/vuln/database) using
    [this ticket-opening shortcut](https://go.dev/s/vulndb-report-new), as
    [documented in the announcement blog-post](https://go.dev/blog/vuln).
-5. Notify Slack in various places: natsio #general, gophers #nats
-6. If really disastrous, consider getting a tweet tweeted from the official
+6. Notify Slack in various places: natsio #general, gophers #nats
+7. If really disastrous, consider getting a tweet tweeted from the official
    account.
-7. Update the official CVE registration details.
+8. (Update the official CVE registration details.) -- this should be handled
+   by GitHub once the advisory is marked public.
 
 
 ## Local development


### PR DESCRIPTION
Clean up the process description to reflect GHSA now being primary as the means we use to get a CVE.  Mention the Go vulnerability database more.

Strongly suggest a grep for `FIXME`.

Eat humble pie.